### PR TITLE
Use WellKnown Empty message and drop missing Quic package

### DIFF
--- a/src/RM.Proto/processes.proto
+++ b/src/RM.Proto/processes.proto
@@ -1,10 +1,12 @@
 syntax = "proto3";
 option csharp_namespace = "RM.Proto";
 
+import "google/protobuf/empty.proto";
+
 package rm;
 
 service ProcessesService {
-  rpc List (Empty) returns (ProcessList);
+  rpc List (google.protobuf.Empty) returns (ProcessList);
   rpc Start (StartRequest) returns (StartReply);
   rpc Kill (Pid) returns (OpStatus);
   rpc Get  (Pid) returns (ProcessInfo);

--- a/src/RM.Proto/system.proto
+++ b/src/RM.Proto/system.proto
@@ -1,15 +1,15 @@
 syntax = "proto3";
 option csharp_namespace = "RM.Proto";
 
+import "google/protobuf/empty.proto";
+
 package rm;
 
 service SystemService {
-  rpc GetInfo (Empty) returns (SystemInfo);
+  rpc GetInfo (google.protobuf.Empty) returns (SystemInfo);
   rpc Ping (PingRequest) returns (PingReply);
-  rpc Uptime (Empty) returns (UptimeReply);
+  rpc Uptime (google.protobuf.Empty) returns (UptimeReply);
 }
-
-message Empty {}
 
 message PingRequest { int64 ts = 1; }
 message PingReply   { int64 ts = 1; int64 echo_ts = 2; }

--- a/src/RMAgent/RMAgent.csproj
+++ b/src/RMAgent/RMAgent.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Extensions.Hosting" />
-    <PackageReference Include="System.Net.Quic" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RM.Shared\RM.Shared.csproj" />

--- a/src/RMAgent/Services/ProcessesServiceImpl.cs
+++ b/src/RMAgent/Services/ProcessesServiceImpl.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Grpc.Core;
+using Google.Protobuf.WellKnownTypes;
 using RM.Proto;
 
 namespace RMAgent.Services;

--- a/src/RMAgent/Services/SystemServiceImpl.cs
+++ b/src/RMAgent/Services/SystemServiceImpl.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Grpc.Core;
+using Google.Protobuf.WellKnownTypes;
 using RM.Proto;
 
 namespace RMAgent.Services;

--- a/src/RemoteManager/Services/ProcessClient.cs
+++ b/src/RemoteManager/Services/ProcessClient.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Grpc.Net.Client;
+using Google.Protobuf.WellKnownTypes;
 using RM.Proto;
 
 namespace RemoteManager.Services;

--- a/src/RemoteManager/Services/SystemClient.cs
+++ b/src/RemoteManager/Services/SystemClient.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Grpc.Net.Client;
+using Google.Protobuf.WellKnownTypes;
 using RM.Proto;
 
 namespace RemoteManager.Services;


### PR DESCRIPTION
## Summary
- Switch proto services to use `google.protobuf.Empty` instead of custom message
- Remove obsolete `System.Net.Quic` package reference
- Update client and service implementations for the new Empty type

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa30fa98c08332ba7491834bc560a9