### PR TITLE
Refactor proto definitions and pin dependency versions

### DIFF
--- a/src/RM.Proto/RM.Proto.csproj
+++ b/src/RM.Proto/RM.Proto.csproj
@@ -5,13 +5,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" />
-    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.57.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.57.0" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="system.proto" GrpcServices="Both" />
     <Protobuf Include="files.proto" GrpcServices="Both" />
     <Protobuf Include="processes.proto" GrpcServices="Both" />
     <Protobuf Include="discovery.proto" GrpcServices="Both" />
+    <Protobuf Include="status.proto" GrpcServices="Both" />
   </ItemGroup>
 </Project>

--- a/src/RM.Proto/files.proto
+++ b/src/RM.Proto/files.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 option csharp_namespace = "RM.Proto";
+import "status.proto";
 
 package rm;
 
@@ -38,4 +39,3 @@ message FileChunk {
   string transfer_id = 4;
 }
 
-message OpStatus { bool ok = 1; string error = 2; }

--- a/src/RM.Proto/processes.proto
+++ b/src/RM.Proto/processes.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 option csharp_namespace = "RM.Proto";
 
 import "google/protobuf/empty.proto";
+import "status.proto";
 
 package rm;
 
@@ -32,4 +33,3 @@ message StartRequest {
 }
 message StartReply { bool ok = 1; string error = 2; int32 pid = 3; }
 
-message OpStatus { bool ok = 1; string error = 2; }

--- a/src/RM.Proto/status.proto
+++ b/src/RM.Proto/status.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+option csharp_namespace = "RM.Proto";
+
+package rm;
+
+message OpStatus {
+  bool ok = 1;
+  string error = 2;
+}

--- a/src/RM.Shared/RM.Shared.csproj
+++ b/src/RM.Shared/RM.Shared.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Serilog" />
-    <PackageReference Include="Serilog.Sinks.File" />
-    <PackageReference Include="Serilog.Extensions.Hosting" />
-    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RM.Proto\RM.Proto.csproj" />

--- a/src/RMAgent/RMAgent.csproj
+++ b/src/RMAgent/RMAgent.csproj
@@ -5,11 +5,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" />
-    <PackageReference Include="Google.Protobuf" />
-    <PackageReference Include="Serilog" />
-    <PackageReference Include="Serilog.Sinks.File" />
-    <PackageReference Include="Serilog.Extensions.Hosting" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RM.Shared\RM.Shared.csproj" />

--- a/src/RemoteManager/RemoteManager.csproj
+++ b/src/RemoteManager/RemoteManager.csproj
@@ -7,12 +7,12 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.Client" />
-    <PackageReference Include="Google.Protobuf" />
-    <PackageReference Include="CommunityToolkit.Mvvm" />
-    <PackageReference Include="Serilog" />
-    <PackageReference Include="Serilog.Sinks.File" />
-    <PackageReference Include="Serilog.Extensions.Hosting" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.57.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RM.Shared\RM.Shared.csproj" />

--- a/tests/RM.Tests/RM.Tests.csproj
+++ b/tests/RM.Tests/RM.Tests.csproj
@@ -5,9 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\RM.Shared\RM.Shared.csproj" />


### PR DESCRIPTION
## Summary
- Extract shared OpStatus message into dedicated status.proto
- Pin explicit versions for gRPC, Serilog, and testing packages
- Include gRPC core API to compile generated services

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 - package install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68aa323cbce88332bd56b821a3ca9766