### PR TITLE
fix: add aspnetcore reference and hash algorithm namespace

### DIFF
--- a/src/RM.Shared/RM.Shared.csproj
+++ b/src/RM.Shared/RM.Shared.csproj
@@ -11,6 +11,9 @@
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
   </ItemGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\RM.Proto\RM.Proto.csproj" />
   </ItemGroup>
 </Project>

--- a/src/RM.Shared/TlsOptionsFactory.cs
+++ b/src/RM.Shared/TlsOptionsFactory.cs
@@ -1,4 +1,5 @@
 using System.Security.Authentication;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 
@@ -7,11 +8,25 @@ namespace RM.Shared;
 public static class TlsOptionsFactory
 {
     public static HttpsConnectionAdapterOptions CreateHttp2(X509Certificate2 cert)
-        => new() { ServerCertificate = cert, SslProtocols = SslProtocols.Tls13 };
+    {
+        return new HttpsConnectionAdapterOptions
+        {
+            ServerCertificate = cert,
+            SslProtocols = SslProtocols.Tls13
+        };
+    }
 
     public static HttpsConnectionAdapterOptions CreateHttp3(X509Certificate2 cert)
-        => new() { ServerCertificate = cert, SslProtocols = SslProtocols.Tls13 };
+    {
+        return new HttpsConnectionAdapterOptions
+        {
+            ServerCertificate = cert,
+            SslProtocols = SslProtocols.Tls13
+        };
+    }
 
     public static string FingerprintSha256(X509Certificate2 cert)
-        => Convert.ToHexString(cert.GetCertHash(HashAlgorithmName.SHA256));
+    {
+        return Convert.ToHexString(cert.GetCertHash(HashAlgorithmName.SHA256));
+    }
 }


### PR DESCRIPTION
## Summary
- use Microsoft.AspNetCore.App framework reference for shared library
- import HashAlgorithmName namespace and expand TLS helper methods

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa358eaba48332935c88f24587da42