### PR TITLE
Fix UDP send API and simplify SDK usage

### DIFF
--- a/src/RemoteManager/RemoteManager.csproj
+++ b/src/RemoteManager/RemoteManager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>


### PR DESCRIPTION
## Summary
- fix DiscoverySocket to use new UdpClient.SendAsync API and dispose properly
- convert DiscoverySocket to block-scoped namespace and block-bodied methods
- switch RemoteManager project to Microsoft.NET.Sdk

## Testing
- `dotnet format RemoteManager.sln --include src/RM.Shared/DiscoverySocket.cs src/RemoteManager/RemoteManager.csproj` *(failed: command not found)*
- `apt-get update` *(failed: repository InRelease not signed)*
- `dotnet build` *(failed: command not found)*
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3684c66c83328f56d5529769928f