### PR TITLE
Add development configuration and conditional network startup

### DIFF
--- a/docs/RUN_DEV.md
+++ b/docs/RUN_DEV.md
@@ -1,0 +1,6 @@
+# Dev run
+Set DOTNET_ENVIRONMENT=Development
+
+1) Запусти RMAgent (слушает 127.0.0.1:8443 tcp/udp)
+2) Запусти RemoteManager (WPF). Сервер и discovery отключены, только gRPC-клиент.
+3) В UI нажми Connect → используй endpoint из Client.DefaultAgentEndpoint (по умолчанию https://127.0.0.1:8443).

--- a/src/RM.Shared/AppEnvironment.cs
+++ b/src/RM.Shared/AppEnvironment.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace RM.Shared;
+
+public static class AppEnvironment
+{
+    public static bool IsDevelopment(IConfiguration cfg)
+    {
+        var env = cfg["DOTNET_ENVIRONMENT"] ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        return string.Equals(env, "Development", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/RM.Shared/DevCertLoader.cs
+++ b/src/RM.Shared/DevCertLoader.cs
@@ -1,18 +1,16 @@
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Configuration;
 
 namespace RM.Shared;
 
 public static class DevCertLoader
 {
-    public static X509Certificate2 Load()
+    public static X509Certificate2 Load(IConfiguration cfg)
     {
-        var certDir = Path.Combine(AppContext.BaseDirectory, "..", "certificates", "dev");
-        if (!Directory.Exists(certDir))
-            throw new DirectoryNotFoundException(certDir);
-        var file = Directory.GetFiles(certDir, "*.pfx").FirstOrDefault()
-                   ?? throw new FileNotFoundException("No dev certificate", certDir);
-        return new X509Certificate2(file, "dev", X509KeyStorageFlags.Exportable);
+        var path = cfg["Security:DevCertPath"] ?? throw new FileNotFoundException("Security:DevCertPath not set");
+        var password = cfg["Security:DevCertPassword"];
+        var fullPath = Path.Combine(AppContext.BaseDirectory, path);
+        return new X509Certificate2(fullPath, password, X509KeyStorageFlags.Exportable);
     }
 }

--- a/src/RMAgent/DiscoveryWorker.cs
+++ b/src/RMAgent/DiscoveryWorker.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using RM.Shared;
@@ -11,35 +12,38 @@ public class DiscoveryWorker : BackgroundService
 {
     private readonly DiscoverySocket _socket;
     private readonly ILogger<DiscoveryWorker> _logger;
-    private const string Psk = "dev-psk-please-change";
+    private readonly IConfiguration _config;
 
-    public DiscoveryWorker(DiscoverySocket socket, ILogger<DiscoveryWorker> logger)
+    public DiscoveryWorker(DiscoverySocket socket, ILogger<DiscoveryWorker> logger, IConfiguration config)
     {
         _socket = socket;
         _logger = logger;
+        _config = config;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var cert = DevCertLoader.Load();
-        var hello = BuildMessage(Discovery.Types.MsgType.HELLO, cert);
-        var bytes = DiscoverySerializer.Serialize(hello, Psk);
-        await _socket.SendAsync(bytes, new IPEndPoint(IPAddress.Broadcast, 8443), stoppingToken);
+        var cert = DevCertLoader.Load(_config);
+        var psk = _config["Security:DiscoveryPsk"] ?? string.Empty;
+        var port = _config.GetValue<int>("Network:Port");
+        var hello = BuildMessage(Discovery.Types.MsgType.HELLO, cert, port);
+        var bytes = DiscoverySerializer.Serialize(hello, psk);
+        await _socket.SendAsync(bytes, new IPEndPoint(IPAddress.Broadcast, port), stoppingToken);
 
         await foreach (var (ep, data) in _socket.ReceiveAsync(stoppingToken))
         {
-            if (!DiscoverySerializer.TryDeserialize(data, Psk, out var msg))
+            if (!DiscoverySerializer.TryDeserialize(data, psk, out var msg))
                 continue;
             if (msg.Type == Discovery.Types.MsgType.DISCOVER)
             {
-                var offer = BuildMessage(Discovery.Types.MsgType.OFFER, cert);
-                var offerBytes = DiscoverySerializer.Serialize(offer, Psk);
+                var offer = BuildMessage(Discovery.Types.MsgType.OFFER, cert, port);
+                var offerBytes = DiscoverySerializer.Serialize(offer, psk);
                 await _socket.SendAsync(offerBytes, ep, stoppingToken);
             }
         }
     }
 
-    private static Discovery BuildMessage(Discovery.Types.MsgType type, System.Security.Cryptography.X509Certificates.X509Certificate2 cert)
+    private static Discovery BuildMessage(Discovery.Types.MsgType type, System.Security.Cryptography.X509Certificates.X509Certificate2 cert, int port)
         => new()
         {
             Type = type,
@@ -48,7 +52,7 @@ public class DiscoveryWorker : BackgroundService
             Hostname = Environment.MachineName,
             Os = Environment.OSVersion.ToString(),
             Arch = RuntimeInformation.OSArchitecture.ToString(),
-            Endpoints = new Endpoints { H2 = true, Port = 8443 },
+            Endpoints = new Endpoints { H2 = true, Port = port },
             CertFingerprintSha256 = TlsOptionsFactory.FingerprintSha256(cert)
         };
 }

--- a/src/RMAgent/Program.cs
+++ b/src/RMAgent/Program.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -8,23 +10,45 @@ using RMAgent.Services;
 using Serilog;
 
 var host = Host.CreateDefaultBuilder(args)
-    .UseSerilog((ctx, cfg) => cfg.WriteTo.File("logs/agent.log", rollingInterval: RollingInterval.Day))
+    .ConfigureAppConfiguration((ctx, cfg) =>
+    {
+        var env = ctx.HostingEnvironment;
+        cfg.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+           .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
+           .AddEnvironmentVariables();
+    })
+    .UseSerilog((ctx, cfg) => cfg.ReadFrom.Configuration(ctx.Configuration))
     .ConfigureServices((ctx, services) =>
     {
         services.AddGrpc();
-        services.AddSingleton(new DiscoverySocket(8443));
-        services.AddHostedService<DiscoveryWorker>();
+        if (ctx.Configuration.GetValue<bool>("Network:EnableDiscovery"))
+        {
+            var port = ctx.Configuration.GetValue<int>("Network:Port");
+            services.AddSingleton(new DiscoverySocket(port));
+            services.AddHostedService<DiscoveryWorker>();
+        }
     })
     .ConfigureWebHostDefaults(webBuilder =>
     {
-        webBuilder.ConfigureKestrel(options =>
+        webBuilder.ConfigureKestrel((ctx, options) =>
         {
-            var cert = DevCertLoader.Load();
-            options.ListenAnyIP(8443, o =>
+            var cfg = ctx.Configuration;
+            var cert = DevCertLoader.Load(cfg);
+            var ip = IPAddress.Parse(cfg["Network:BindIp"]!);
+            var port = cfg.GetValue<int>("Network:Port");
+            options.Listen(ip, port, o =>
             {
                 o.Protocols = HttpProtocols.Http2;
                 o.UseHttps(TlsOptionsFactory.CreateHttp2(cert));
             });
+            if (cfg.GetValue<bool>("Network:EnableUdpQuic"))
+            {
+                options.Listen(ip, port, o =>
+                {
+                    o.Protocols = HttpProtocols.Http3;
+                    o.UseHttps(TlsOptionsFactory.CreateHttp3(cert));
+                });
+            }
         });
         webBuilder.Configure(app =>
         {
@@ -35,7 +59,12 @@ var host = Host.CreateDefaultBuilder(args)
     })
     .Build();
 
+var cfg = host.Services.GetRequiredService<IConfiguration>();
 var logger = host.Services.GetRequiredService<ILogger<Program>>();
-logger.LogInformation("Listening on 8443 TCP");
+var ip = cfg["Network:BindIp"];
+var port = cfg.GetValue<int>("Network:Port");
+logger.LogInformation("Listening on {ip}:{port} (h2)", ip, port);
+if (cfg.GetValue<bool>("Network:EnableUdpQuic"))
+    logger.LogInformation("Listening on {ip}:{port} (h3)", ip, port);
 
 await host.RunAsync();

--- a/src/RMAgent/Properties/launchSettings.json
+++ b/src/RMAgent/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "RMAgent": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/RMAgent/RMAgent.csproj
+++ b/src/RMAgent/RMAgent.csproj
@@ -10,9 +10,14 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RM.Shared\RM.Shared.csproj" />
     <ProjectReference Include="..\RM.Proto\RM.Proto.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/RMAgent/appsettings.Development.json
+++ b/src/RMAgent/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Network": {
+    "BindIp": "127.0.0.1",
+    "Port": 8443,
+    "EnableUdpQuic": false,
+    "EnableDiscovery": true
+  }
+}

--- a/src/RMAgent/appsettings.json
+++ b/src/RMAgent/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Network": {
+    "BindIp": "0.0.0.0",
+    "Port": 8443,
+    "EnableUdpQuic": true,
+    "EnableDiscovery": true
+  },
+  "Security": {
+    "DevCertPath": "certificates/dev/rm-dev-agent.pfx",
+    "DevCertPassword": "dev",
+    "DiscoveryPsk": "dev-psk-please-change"
+  },
+  "Serilog": {
+    "MinimumLevel": "Information",
+    "WriteTo": [ { "Name": "File", "Args": { "path": "logs/agent-.log", "rollingInterval": "Day" } } ]
+  }
+}

--- a/src/RemoteManager/Properties/launchSettings.json
+++ b/src/RemoteManager/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "RemoteManager": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/RemoteManager/RemoteManager.csproj
+++ b/src/RemoteManager/RemoteManager.csproj
@@ -13,9 +13,14 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RM.Shared\RM.Shared.csproj" />
     <ProjectReference Include="..\RM.Proto\RM.Proto.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/RemoteManager/appsettings.Development.json
+++ b/src/RemoteManager/appsettings.Development.json
@@ -1,0 +1,16 @@
+{
+  "Server": {
+    "Enabled": false,
+    "BindIp": "127.0.0.1",
+    "Port": 8443,
+    "EnableUdpQuic": false
+  },
+  "Discovery": {
+    "Enabled": false,
+    "ReceiveEnabled": false,
+    "SendEnabled": false
+  },
+  "Client": {
+    "DefaultAgentEndpoint": "https://127.0.0.1:8443"
+  }
+}

--- a/src/RemoteManager/appsettings.json
+++ b/src/RemoteManager/appsettings.json
@@ -1,0 +1,25 @@
+{
+  "Server": {
+    "Enabled": true,
+    "BindIp": "0.0.0.0",
+    "Port": 8443,
+    "EnableUdpQuic": true
+  },
+  "Discovery": {
+    "Enabled": true,
+    "ReceiveEnabled": true,
+    "SendEnabled": true
+  },
+  "Client": {
+    "DefaultAgentEndpoint": "https://127.0.0.1:8443"
+  },
+  "Security": {
+    "DevCertPath": "certificates/dev/rm-dev-dashboard.pfx",
+    "DevCertPassword": "dev",
+    "DiscoveryPsk": "dev-psk-please-change"
+  },
+  "Serilog": {
+    "MinimumLevel": "Information",
+    "WriteTo": [ { "Name": "File", "Args": { "path": "logs/dashboard-.log", "rollingInterval": "Day" } } ]
+  }
+}


### PR DESCRIPTION
## Summary
- add development and production appsettings for agent and dashboard
- wire up generic host configuration and gate server/discovery features
- bind agent network endpoints from configuration with discovery support
- document development startup

## Testing
- `dotnet build src/RMAgent/RMAgent.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa43c6a81c8332b624c0152f952d51