### PR TITLE
Add Serilog config package and remove redundant content items

### DIFF
--- a/src/RMAgent/Program.cs
+++ b/src/RMAgent/Program.cs
@@ -5,14 +5,15 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Security.Cryptography.X509Certificates;
 using RM.Shared;
 using RMAgent.Services;
 using Serilog;
 
-var host = Host.CreateDefaultBuilder(args)
+IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration((ctx, cfg) =>
     {
-        var env = ctx.HostingEnvironment;
+        IHostEnvironment env = ctx.HostingEnvironment;
         cfg.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
            .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
            .AddEnvironmentVariables();
@@ -23,7 +24,7 @@ var host = Host.CreateDefaultBuilder(args)
         services.AddGrpc();
         if (ctx.Configuration.GetValue<bool>("Network:EnableDiscovery"))
         {
-            var port = ctx.Configuration.GetValue<int>("Network:Port");
+            int port = ctx.Configuration.GetValue<int>("Network:Port");
             services.AddSingleton(new DiscoverySocket(port));
             services.AddHostedService<DiscoveryWorker>();
         }
@@ -32,10 +33,10 @@ var host = Host.CreateDefaultBuilder(args)
     {
         webBuilder.ConfigureKestrel((ctx, options) =>
         {
-            var cfg = ctx.Configuration;
-            var cert = DevCertLoader.Load(cfg);
-            var ip = IPAddress.Parse(cfg["Network:BindIp"]!);
-            var port = cfg.GetValue<int>("Network:Port");
+            IConfiguration cfg = ctx.Configuration;
+            X509Certificate2 cert = DevCertLoader.Load(cfg);
+            IPAddress ip = IPAddress.Parse(cfg["Network:BindIp"]!);
+            int port = cfg.GetValue<int>("Network:Port");
             options.Listen(ip, port, o =>
             {
                 o.Protocols = HttpProtocols.Http2;
@@ -59,12 +60,14 @@ var host = Host.CreateDefaultBuilder(args)
     })
     .Build();
 
-var cfg = host.Services.GetRequiredService<IConfiguration>();
-var logger = host.Services.GetRequiredService<ILogger<Program>>();
-var ip = cfg["Network:BindIp"];
-var port = cfg.GetValue<int>("Network:Port");
+IConfiguration cfg = host.Services.GetRequiredService<IConfiguration>();
+ILogger<Program> logger = host.Services.GetRequiredService<ILogger<Program>>();
+string? ip = cfg["Network:BindIp"];
+int port = cfg.GetValue<int>("Network:Port");
 logger.LogInformation("Listening on {ip}:{port} (h2)", ip, port);
 if (cfg.GetValue<bool>("Network:EnableUdpQuic"))
+{
     logger.LogInformation("Listening on {ip}:{port} (h3)", ip, port);
+}
 
 await host.RunAsync();

--- a/src/RMAgent/RMAgent.csproj
+++ b/src/RMAgent/RMAgent.csproj
@@ -10,14 +10,12 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RM.Shared\RM.Shared.csproj" />
     <ProjectReference Include="..\RM.Proto\RM.Proto.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/RemoteManager/App.xaml.cs
+++ b/src/RemoteManager/App.xaml.cs
@@ -8,57 +8,63 @@ using RemoteManager.ViewModels;
 using RemoteManager.Views;
 using Serilog;
 
-namespace RemoteManager;
-
-public partial class App : Application
+namespace RemoteManager
 {
-    public IHost Host { get; }
-
-    public App()
+    public partial class App : Application
     {
-        Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
-            .ConfigureAppConfiguration((ctx, cfg) =>
+        public IHost Host { get; }
+
+        public App()
+        {
+            Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+                .ConfigureAppConfiguration((ctx, cfg) =>
+                {
+                    IHostEnvironment env = ctx.HostingEnvironment;
+                    cfg.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                       .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                       .AddEnvironmentVariables();
+                })
+                .UseSerilog((ctx, cfg) => cfg.ReadFrom.Configuration(ctx.Configuration))
+                .ConfigureServices((ctx, services) =>
+                {
+                    string endpoint = ctx.Configuration.GetValue<string>("Client:DefaultAgentEndpoint")!;
+                    services.AddSingleton<IDiscoveryService, DiscoveryService>();
+                    services.AddSingleton<IAgentRegistry, AgentRegistry>();
+                    services.AddSingleton<IGrpcConnectionFactory, GrpcConnectionFactory>();
+                    services.AddSingleton<ISystemClient>(sp => new SystemClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));
+                    services.AddSingleton<IFileClient>(sp => new FileClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));
+                    services.AddSingleton<IProcessClient>(sp => new ProcessClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));
+                    services.AddSingleton<ShellViewModel>();
+                    services.AddSingleton<AgentListViewModel>();
+                    services.AddSingleton<CommanderViewModel>();
+                    services.AddSingleton<MainWindow>();
+                })
+                .Build();
+            Host.Start();
+
+            IConfiguration cfg = Host.Services.GetRequiredService<IConfiguration>();
+            ILogger<App> logger = Host.Services.GetRequiredService<ILogger<App>>();
+            if (!cfg.GetValue<bool>("Server:Enabled"))
             {
-                var env = ctx.HostingEnvironment;
-                cfg.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                   .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
-                   .AddEnvironmentVariables();
-            })
-            .UseSerilog((ctx, cfg) => cfg.ReadFrom.Configuration(ctx.Configuration))
-            .ConfigureServices((ctx, services) =>
+                logger.LogInformation("Server startup skipped (dev)");
+            }
+            if (!cfg.GetValue<bool>("Discovery:Enabled") || !cfg.GetValue<bool>("Discovery:ReceiveEnabled"))
             {
-                var endpoint = ctx.Configuration.GetValue<string>("Client:DefaultAgentEndpoint")!;
-                services.AddSingleton<IDiscoveryService, DiscoveryService>();
-                services.AddSingleton<IAgentRegistry, AgentRegistry>();
-                services.AddSingleton<IGrpcConnectionFactory, GrpcConnectionFactory>();
-                services.AddSingleton<ISystemClient>(sp => new SystemClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));
-                services.AddSingleton<IFileClient>(sp => new FileClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));
-                services.AddSingleton<IProcessClient>(sp => new ProcessClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));
-                services.AddSingleton<ShellViewModel>();
-                services.AddSingleton<AgentListViewModel>();
-                services.AddSingleton<CommanderViewModel>();
-                services.AddSingleton<MainWindow>();
-            })
-            .Build();
-        Host.Start();
+                logger.LogInformation("Discovery receive disabled (dev)");
+            }
+        }
 
-        var cfg = Host.Services.GetRequiredService<IConfiguration>();
-        var logger = Host.Services.GetRequiredService<ILogger<App>>();
-        if (!cfg.GetValue<bool>("Server:Enabled"))
-            logger.LogInformation("Server startup skipped (dev)");
-        if (!cfg.GetValue<bool>("Discovery:Enabled") || !cfg.GetValue<bool>("Discovery:ReceiveEnabled"))
-            logger.LogInformation("Discovery receive disabled (dev)");
-    }
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            Host.Services.GetRequiredService<MainWindow>().Show();
+        }
 
-    protected override void OnStartup(StartupEventArgs e)
-    {
-        base.OnStartup(e);
-        Host.Services.GetRequiredService<MainWindow>().Show();
-    }
-
-    protected override void OnExit(ExitEventArgs e)
-    {
-        Host.Dispose();
-        base.OnExit(e);
+        protected override void OnExit(ExitEventArgs e)
+        {
+            Host.Dispose();
+            base.OnExit(e);
+        }
     }
 }
+

--- a/src/RemoteManager/RemoteManager.csproj
+++ b/src/RemoteManager/RemoteManager.csproj
@@ -13,14 +13,12 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RM.Shared\RM.Shared.csproj" />
     <ProjectReference Include="..\RM.Proto\RM.Proto.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- ensure Serilog reads settings from configuration by adding Serilog.Settings.Configuration package
- avoid duplicate appsettings entries by relying on SDK default content items
- tidy startup files with explicit types, braces, and block-scoped namespace

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68aa451921e4833292ee4fb55e8d058b