### PR TITLE
Ensure appsettings files are copied to output

### DIFF
--- a/src/RemoteManager/RemoteManager.csproj
+++ b/src/RemoteManager/RemoteManager.csproj
@@ -18,6 +18,14 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\RM.Shared\RM.Shared.csproj" />
     <ProjectReference Include="..\RM.Proto\RM.Proto.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- copy appsettings.json and environment-specific settings files to the build output so the host can load configuration

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa46836ac88332b2651805a1dca2e4