### PR TITLE
Fix gRPC mapping and discovery enum names

### DIFF
--- a/src/RMAgent/DiscoveryWorker.cs
+++ b/src/RMAgent/DiscoveryWorker.cs
@@ -26,7 +26,7 @@ public class DiscoveryWorker : BackgroundService
         var cert = DevCertLoader.Load(_config);
         var psk = _config["Security:DiscoveryPsk"] ?? string.Empty;
         var port = _config.GetValue<int>("Network:Port");
-        var hello = BuildMessage(Discovery.Types.MsgType.HELLO, cert, port);
+        var hello = BuildMessage(Discovery.Types.MsgType.Hello, cert, port);
         var bytes = DiscoverySerializer.Serialize(hello, psk);
         await _socket.SendAsync(bytes, new IPEndPoint(IPAddress.Broadcast, port), stoppingToken);
 
@@ -34,9 +34,9 @@ public class DiscoveryWorker : BackgroundService
         {
             if (!DiscoverySerializer.TryDeserialize(data, psk, out var msg))
                 continue;
-            if (msg.Type == Discovery.Types.MsgType.DISCOVER)
+            if (msg.Type == Discovery.Types.MsgType.Discover)
             {
-                var offer = BuildMessage(Discovery.Types.MsgType.OFFER, cert, port);
+                var offer = BuildMessage(Discovery.Types.MsgType.Offer, cert, port);
                 var offerBytes = DiscoverySerializer.Serialize(offer, psk);
                 await _socket.SendAsync(offerBytes, ep, stoppingToken);
             }

--- a/src/RMAgent/Program.cs
+++ b/src/RMAgent/Program.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Security.Cryptography.X509Certificates;
 using RM.Shared;
+using RMAgent; // DiscoveryWorker
 using RMAgent.Services;
 using Serilog;
 
@@ -53,9 +55,13 @@ IHost host = Host.CreateDefaultBuilder(args)
         });
         webBuilder.Configure(app =>
         {
-            app.MapGrpcService<SystemServiceImpl>();
-            app.MapGrpcService<FilesServiceCore>();
-            app.MapGrpcService<ProcessesServiceImpl>();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGrpcService<SystemServiceImpl>();
+                endpoints.MapGrpcService<FilesServiceCore>();
+                endpoints.MapGrpcService<ProcessesServiceImpl>();
+            });
         });
     })
     .Build();

--- a/src/RMAgent/Services/ProcessesServiceImpl.cs
+++ b/src/RMAgent/Services/ProcessesServiceImpl.cs
@@ -29,7 +29,7 @@ namespace RMAgent.Services
         {
             try
             {
-                Process proc = Process.GetProcessById(request.Pid);
+                Process proc = Process.GetProcessById(request.Pid_);
                 proc.Kill();
                 return Task.FromResult(new OpStatus { Ok = true });
             }


### PR DESCRIPTION
## Summary
- use routing/endpoints to map gRPC services
- correct discovery message enum names
- reference generated Pid_ property in process service

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4c0aa6ec833280d3019bfdfeedc5