### PR TITLE
Fix discovery component compilation errors

### DIFF
--- a/src/RMAgent/DiscoveryWorker.cs
+++ b/src/RMAgent/DiscoveryWorker.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using RM.Shared;
 using RM.Shared.Security;
 using RM.Proto;
 
@@ -22,7 +23,7 @@ public class DiscoveryWorker : BackgroundService
         _socket = socket;
         _logger = logger;
         _config = config;
-        _deviceId = DeviceIdentity.EnsureDeviceId(Path.Combine(AppContext.BaseDirectory, "device.id"));
+        _deviceId = DeviceIdentity.EnsureDeviceId(System.IO.Path.Combine(AppContext.BaseDirectory, "device.id"));
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -34,7 +35,7 @@ public class DiscoveryWorker : BackgroundService
         var bytes = DiscoverySerializer.Serialize(hello, psk);
         await _socket.SendAsync(bytes, new IPEndPoint(IPAddress.Broadcast, port), stoppingToken);
 
-        await foreach (var (ep, data) in _socket.ReceiveAsync(stoppingToken))
+        await foreach ((IPEndPoint ep, byte[] data) in _socket.ReceiveAsync(stoppingToken))
         {
             if (!DiscoverySerializer.TryDeserialize(data, psk, out var msg))
                 continue;

--- a/src/RMAgent/Program.cs
+++ b/src/RMAgent/Program.cs
@@ -6,12 +6,13 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using RM.Shared;
 using RM.Shared.Security;
 using RMAgent; // DiscoveryWorker
 using RMAgent.Services;
 using Serilog;
 
-var deviceId = DeviceIdentity.EnsureDeviceId(Path.Combine(AppContext.BaseDirectory, "device.id"));
+var deviceId = DeviceIdentity.EnsureDeviceId(System.IO.Path.Combine(AppContext.BaseDirectory, "device.id"));
 
 IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration((ctx, cfg) =>


### PR DESCRIPTION
## Summary
- import RM.Shared for discovery socket and serializer
- resolve Path type conflict with System.IO.Path
- specify tuple types in discovery worker receive loop

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab019f2ad483329ae97695c9655ddf