### PR TITLE
feat: trusted agent store and certificate tests

### DIFF
--- a/src/RemoteManager/App.xaml.cs
+++ b/src/RemoteManager/App.xaml.cs
@@ -29,6 +29,7 @@ namespace RemoteManager
                 {
                     string endpoint = ctx.Configuration.GetValue<string>("Client:DefaultAgentEndpoint")!;
                     services.AddSingleton<IDiscoveryService, DiscoveryService>();
+                    services.AddSingleton<RemoteManager.Security.TrustedAgentsStore>();
                     services.AddSingleton<IAgentRegistry, AgentRegistry>();
                     services.AddSingleton<IGrpcConnectionFactory, GrpcConnectionFactory>();
                     services.AddSingleton<ISystemClient>(sp => new SystemClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));

--- a/src/RemoteManager/Models/AgentEndpoint.cs
+++ b/src/RemoteManager/Models/AgentEndpoint.cs
@@ -4,8 +4,11 @@ namespace RemoteManager.Models;
 
 public class AgentEndpoint
 {
-    public string DeviceId { get; set; } = "";
-    public string Hostname { get; set; } = "";
-    public string Os { get; set; } = "";
+    public string DeviceId { get; set; } = string.Empty;
+    public string Hostname { get; set; } = string.Empty;
+    public string Os { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string Fingerprint { get; set; } = string.Empty;
+    public bool IsTrusted { get; set; }
     public string[] Caps { get; set; } = Array.Empty<string>();
 }

--- a/src/RemoteManager/Security/Fingerprint.cs
+++ b/src/RemoteManager/Security/Fingerprint.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace RemoteManager.Security;
+
+public static class Fingerprint
+{
+    public static string ComputeSha256(X509Certificate2 cert)
+    {
+        var hash = cert.GetCertHash(HashAlgorithmName.SHA256);
+        return string.Join(":", hash.Select(b => b.ToString("X2")));
+    }
+}

--- a/src/RemoteManager/Security/TrustedAgentsStore.cs
+++ b/src/RemoteManager/Security/TrustedAgentsStore.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace RemoteManager.Security;
+
+public class TrustedAgent
+{
+    public string DeviceId { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string FingerprintSha256 { get; set; } = string.Empty;
+    public string Hostname { get; set; } = string.Empty;
+    public DateTime AddedUtc { get; set; } = DateTime.UtcNow;
+}
+
+public class TrustedAgentsStore
+{
+    private readonly string _filePath;
+    private readonly List<TrustedAgent> _agents = new();
+
+    public TrustedAgentsStore(string? path = null)
+    {
+        _filePath = path ?? GetDefaultPath();
+        Load();
+    }
+
+    private static string GetDefaultPath()
+    {
+        string baseDir;
+        try
+        {
+            baseDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "RemoteManager");
+        }
+        catch
+        {
+            baseDir = Path.Combine(AppContext.BaseDirectory, "data");
+        }
+        Directory.CreateDirectory(baseDir);
+        return Path.Combine(baseDir, "trusted_agents.json");
+    }
+
+    public void Load()
+    {
+        _agents.Clear();
+        if (File.Exists(_filePath))
+        {
+            try
+            {
+                var json = File.ReadAllText(_filePath);
+                var list = JsonSerializer.Deserialize<List<TrustedAgent>>(json);
+                if (list != null)
+                    _agents.AddRange(list);
+            }
+            catch { }
+        }
+    }
+
+    public void Save()
+    {
+        var json = JsonSerializer.Serialize(_agents, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(_filePath, json);
+    }
+
+    public IEnumerable<TrustedAgent> List() => _agents;
+
+    public void AddOrUpdate(TrustedAgent agent)
+    {
+        var existing = _agents.FirstOrDefault(a => a.Address == agent.Address ||
+                                                   (!string.IsNullOrEmpty(agent.DeviceId) && a.DeviceId == agent.DeviceId));
+        if (existing != null)
+        {
+            existing.FingerprintSha256 = agent.FingerprintSha256;
+            existing.Hostname = agent.Hostname;
+            existing.DeviceId = agent.DeviceId;
+        }
+        else
+        {
+            agent.AddedUtc = DateTime.UtcNow;
+            _agents.Add(agent);
+        }
+        Save();
+    }
+
+    public bool TryGetByAddress(string address, out TrustedAgent? agent)
+    {
+        agent = _agents.FirstOrDefault(a => a.Address == address);
+        return agent != null;
+    }
+
+    public bool ContainsFingerprint(string fingerprint)
+        => _agents.Any(a => a.FingerprintSha256.Equals(fingerprint, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/RemoteManager/Services/AgentRegistry.cs
+++ b/src/RemoteManager/Services/AgentRegistry.cs
@@ -1,14 +1,32 @@
 using System.Collections.ObjectModel;
+using System.Linq;
 using RemoteManager.Models;
+using RemoteManager.Security;
 
 namespace RemoteManager.Services;
 
 public class AgentRegistry : IAgentRegistry
 {
+    private readonly TrustedAgentsStore _store;
     public ObservableCollection<AgentEndpoint> Agents { get; } = new();
+
+    public AgentRegistry(TrustedAgentsStore store)
+    {
+        _store = store;
+    }
 
     public void AddOrUpdate(AgentEndpoint agent)
     {
-        Agents.Add(agent);
+        agent.IsTrusted = _store.ContainsFingerprint(agent.Fingerprint);
+        var existing = Agents.FirstOrDefault(a => a.Address == agent.Address);
+        if (existing != null)
+        {
+            var idx = Agents.IndexOf(existing);
+            Agents[idx] = agent;
+        }
+        else
+        {
+            Agents.Add(agent);
+        }
     }
 }

--- a/src/RemoteManager/Services/GrpcConnectionFactory.cs
+++ b/src/RemoteManager/Services/GrpcConnectionFactory.cs
@@ -1,9 +1,37 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
 using Grpc.Net.Client;
+using Microsoft.Extensions.Configuration;
+using RemoteManager.Security;
 
 namespace RemoteManager.Services;
 
 public class GrpcConnectionFactory : IGrpcConnectionFactory
 {
+    private readonly TrustedAgentsStore _store;
+    private readonly IConfiguration _cfg;
+
+    public GrpcConnectionFactory(TrustedAgentsStore store, IConfiguration cfg)
+    {
+        _store = store;
+        _cfg = cfg;
+    }
+
     public GrpcChannel Create(string address)
-        => GrpcChannel.ForAddress(address);
+    {
+        var handler = new HttpClientHandler();
+        handler.ServerCertificateCustomValidationCallback = (msg, cert, chain, errors) =>
+        {
+            if (cert == null) return false;
+            string fp = Fingerprint.ComputeSha256(cert);
+            if (_store.ContainsFingerprint(fp)) return true;
+            return !_cfg.GetValue<bool>("Security:PinningRequired");
+        };
+        var httpClient = new HttpClient(handler);
+        httpClient.DefaultRequestVersion = new Version(2, 0);
+        httpClient.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+        return GrpcChannel.ForAddress(address, new GrpcChannelOptions { HttpClient = httpClient });
+    }
 }

--- a/tests/RM.Tests/CertTests.cs
+++ b/tests/RM.Tests/CertTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Configuration;
+using RM.Shared.Security;
+using Xunit;
+
+namespace RM.Tests;
+
+public class CertTests
+{
+    [Fact]
+    public void EnsureServerCertificate_HasSan()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pfx");
+        var cfgDict = new Dictionary<string, string?>
+        {
+            ["Security:DevCertPath"] = tempPath,
+            ["Security:DevCertPassword"] = string.Empty,
+            ["Security:Subject"] = "CN=Test",
+            ["Security:AddHostnamesToSAN"] = "true",
+            ["Security:AddIPsToSAN"] = "true"
+        };
+        var cfg = new ConfigurationBuilder().AddInMemoryCollection(cfgDict).Build();
+        var cert = CertManager.EnsureServerCertificate(cfg, "Agent");
+        var sanExt = cert.Extensions["2.5.29.17"];
+        Assert.NotNull(sanExt);
+        string san = new AsnEncodedData(sanExt!.Oid, sanExt.RawData).Format(true);
+        var host = CertManager.CollectHostnames().First();
+        var ip = CertManager.CollectIPs().First();
+        Assert.Contains(host, san, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(ip.ToString(), san);
+    }
+}


### PR DESCRIPTION
## Summary
- add fingerprint computation helper and persistent trusted agent store
- enhance gRPC connection factory with certificate pinning based on trusted store
- add unit test validating SAN entries on generated certificates

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab42bb31e88332957998dc9a863109