### PR TITLE
feat: add agents view with filtering and details

### DIFF
--- a/src/RemoteManager/App.xaml
+++ b/src/RemoteManager/App.xaml
@@ -2,5 +2,11 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Theme/Theme.xaml" />
+                <ResourceDictionary Source="Resources/Strings.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/RemoteManager/Converters/EnumToBooleanConverter.cs
+++ b/src/RemoteManager/Converters/EnumToBooleanConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace RemoteManager.Converters;
+
+public class EnumToBooleanConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null) return false;
+        var enumValue = value.ToString();
+        var targetValue = parameter.ToString();
+        return enumValue != null && enumValue.Equals(targetValue);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b && b && parameter is string str)
+        {
+            return Enum.Parse(targetType, str);
+        }
+        return Binding.DoNothing;
+    }
+}

--- a/src/RemoteManager/Resources/Strings.xaml
+++ b/src/RemoteManager/Resources/Strings.xaml
@@ -1,0 +1,63 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Column headers -->
+    <x:String x:Key="Agents.Header.Status">Status</x:String>
+    <x:String x:Key="Agents.Header.Name">Name</x:String>
+    <x:String x:Key="Agents.Header.Host">Host/IP</x:String>
+    <x:String x:Key="Agents.Header.Group">Group/Tags</x:String>
+    <x:String x:Key="Agents.Header.Version">Version</x:String>
+    <x:String x:Key="Agents.Header.Uptime">Uptime</x:String>
+    <x:String x:Key="Agents.Header.Platform">Platform</x:String>
+    <x:String x:Key="Agents.Header.CpuRam">CPU/RAM</x:String>
+    <x:String x:Key="Agents.Header.Ping">Ping</x:String>
+    <x:String x:Key="Agents.Header.LastSeen">Last Seen</x:String>
+    <x:String x:Key="Agents.Header.Fingerprint">Fingerprint</x:String>
+    <x:String x:Key="Agents.Header.Actions">Actions</x:String>
+
+    <!-- Filters -->
+    <x:String x:Key="Agents.Filter.All">All</x:String>
+    <x:String x:Key="Agents.Filter.Online">Online</x:String>
+    <x:String x:Key="Agents.Filter.Offline">Offline</x:String>
+    <x:String x:Key="Agents.Filter.Pending">Pending</x:String>
+    <x:String x:Key="Agents.Filter.Quarantine">Quarantine</x:String>
+
+    <!-- Actions -->
+    <x:String x:Key="Agents.Action.OpenDetails">Open Details</x:String>
+    <x:String x:Key="Agents.Action.Trust">Trust</x:String>
+    <x:String x:Key="Agents.Action.Reject">Reject</x:String>
+    <x:String x:Key="Agents.Action.Files">Files</x:String>
+    <x:String x:Key="Agents.Action.Terminal">Terminal</x:String>
+    <x:String x:Key="Agents.Action.Restart">Restart</x:String>
+
+    <!-- Search -->
+    <x:String x:Key="Agents.Search.Placeholder">Search agents...</x:String>
+    <x:String x:Key="Icon.Search">&#xE721;</x:String>
+
+    <!-- Empty state -->
+    <x:String x:Key="Agents.Empty.Message">No agents found</x:String>
+    <x:String x:Key="Agents.Empty.ScanNetwork">Scan network</x:String>
+    <x:String x:Key="Agents.Empty.AddManual">Add manually</x:String>
+
+    <!-- Details -->
+    <x:String x:Key="Agents.Details.DeviceId">DeviceId</x:String>
+    <x:String x:Key="Agents.Details.Hostname">Hostname</x:String>
+    <x:String x:Key="Agents.Details.IPs">IPs</x:String>
+    <x:String x:Key="Agents.Details.Tags">Tags</x:String>
+    <x:String x:Key="Agents.Details.Fingerprint">Fingerprint</x:String>
+    <x:String x:Key="Agents.Details.TrustStatus">Trust Status</x:String>
+    <x:String x:Key="Agents.Details.Cert">Cert</x:String>
+    <x:String x:Key="Agents.Details.Subject">Subject</x:String>
+    <x:String x:Key="Agents.Details.NotBefore">Not Before</x:String>
+    <x:String x:Key="Agents.Details.NotAfter">Not After</x:String>
+    <x:String x:Key="Agents.Details.SAN">SAN</x:String>
+    <x:String x:Key="Agents.Details.Uptime">Uptime</x:String>
+    <x:String x:Key="Agents.Details.Version">Version</x:String>
+    <x:String x:Key="Agents.Details.LastErrors">Last Errors</x:String>
+    <x:String x:Key="Agents.Details.TrustBtn">Trust</x:String>
+    <x:String x:Key="Agents.Details.RejectBtn">Reject</x:String>
+    <x:String x:Key="Agents.Details.QuarantineBtn">Quarantine</x:String>
+    <x:String x:Key="Agents.Details.RenameBtn">Rename</x:String>
+    <x:String x:Key="Agents.Details.AssignTagsBtn">Assign Tags</x:String>
+    <x:String x:Key="Agents.Details.RestartBtn">Restart Agent</x:String>
+    <x:String x:Key="Agents.Details.CloseBtn">Close</x:String>
+</ResourceDictionary>

--- a/src/RemoteManager/Resources/Theme/Badges.xaml
+++ b/src/RemoteManager/Resources/Theme/Badges.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style x:Key="Badge.Base" TargetType="Border">
+        <Setter Property="CornerRadius" Value="4" />
+        <Setter Property="Padding" Value="4,2" />
+        <Setter Property="Background" Value="{DynamicResource Brush.Foreground}" />
+    </Style>
+
+    <Style x:Key="Badge.Online" TargetType="Border" BasedOn="{StaticResource Badge.Base}">
+        <Setter Property="Background" Value="{DynamicResource Brush.Success}" />
+    </Style>
+    <Style x:Key="Badge.Pending" TargetType="Border" BasedOn="{StaticResource Badge.Base}">
+        <Setter Property="Background" Value="{DynamicResource Brush.Warning}" />
+    </Style>
+    <Style x:Key="Badge.Quarantine" TargetType="Border" BasedOn="{StaticResource Badge.Base}">
+        <Setter Property="Background" Value="{DynamicResource Brush.Danger}" />
+    </Style>
+    <Style x:Key="Badge.Offline" TargetType="Border" BasedOn="{StaticResource Badge.Base}">
+        <Setter Property="Background" Value="{DynamicResource Brush.Foreground}" />
+    </Style>
+</ResourceDictionary>

--- a/src/RemoteManager/Resources/Theme/Colors.xaml
+++ b/src/RemoteManager/Resources/Theme/Colors.xaml
@@ -1,0 +1,15 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Neutral palette -->
+    <Color x:Key="Color.Background">#FFFFFFFF</Color>
+    <Color x:Key="Color.Foreground">#FF202020</Color>
+    <Color x:Key="Color.Success">#FF4CAF50</Color>
+    <Color x:Key="Color.Warning">#FFFFC107</Color>
+    <Color x:Key="Color.Danger">#FFF44336</Color>
+
+    <SolidColorBrush x:Key="Brush.Background" Color="{StaticResource Color.Background}" />
+    <SolidColorBrush x:Key="Brush.Foreground" Color="{StaticResource Color.Foreground}" />
+    <SolidColorBrush x:Key="Brush.Success" Color="{StaticResource Color.Success}" />
+    <SolidColorBrush x:Key="Brush.Warning" Color="{StaticResource Color.Warning}" />
+    <SolidColorBrush x:Key="Brush.Danger" Color="{StaticResource Color.Danger}" />
+</ResourceDictionary>

--- a/src/RemoteManager/Resources/Theme/Theme.xaml
+++ b/src/RemoteManager/Resources/Theme/Theme.xaml
@@ -1,0 +1,27 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Colors.xaml" />
+        <ResourceDictionary Source="Badges.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <!-- Button styles -->
+    <Style x:Key="PrimaryButton" TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource Brush.Success}" />
+        <Setter Property="Foreground" Value="{DynamicResource Brush.Background}" />
+        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="BorderBrush" Value="{DynamicResource Brush.Success}" />
+    </Style>
+
+    <Style x:Key="GhostButton" TargetType="Button">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{DynamicResource Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource Brush.Foreground}" />
+        <Setter Property="Padding" Value="8,4" />
+    </Style>
+
+    <Style x:Key="DangerButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
+        <Setter Property="Background" Value="{DynamicResource Brush.Danger}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource Brush.Danger}" />
+    </Style>
+</ResourceDictionary>

--- a/src/RemoteManager/ViewModels/Agents/AgentItemVm.cs
+++ b/src/RemoteManager/ViewModels/Agents/AgentItemVm.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+
+namespace RemoteManager.ViewModels.Agents;
+
+public enum AgentStatus
+{
+    All,
+    Online,
+    Offline,
+    Pending,
+    Quarantine
+}
+
+public class AgentItemVm : ObservableObject
+{
+    public AgentStatus Status { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Host { get; set; } = string.Empty;
+    public string Tags { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+    public string Uptime { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public string CpuRam { get; set; } = string.Empty;
+    public string Ping { get; set; } = string.Empty;
+    public string LastSeen { get; set; } = string.Empty;
+    public string Fingerprint { get; set; } = string.Empty;
+    public Guid DeviceId { get; set; } = Guid.NewGuid();
+}

--- a/src/RemoteManager/ViewModels/Agents/AgentsViewModel.cs
+++ b/src/RemoteManager/ViewModels/Agents/AgentsViewModel.cs
@@ -1,0 +1,108 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
+using System.Windows;
+
+namespace RemoteManager.ViewModels.Agents;
+
+public partial class AgentsViewModel : ObservableObject
+{
+    public ObservableCollection<AgentItemVm> Items { get; } = new();
+    public ICollectionView View { get; }
+
+    [ObservableProperty]
+    private AgentItemVm? selectedItem;
+
+    [ObservableProperty]
+    private bool isDetailsOpen;
+
+    [ObservableProperty]
+    private AgentStatus activeStatusFilter = AgentStatus.All;
+
+    private string searchQuery = string.Empty;
+    public string SearchQuery
+    {
+        get => searchQuery;
+        set
+        {
+            if (SetProperty(ref searchQuery, value))
+            {
+                DebounceFilter();
+            }
+        }
+    }
+
+    private CancellationTokenSource? searchDebounceCts;
+
+    public AgentsViewModel()
+    {
+        View = CollectionViewSource.GetDefaultView(Items);
+        View.Filter = Filter;
+        Seed();
+    }
+
+    private void Seed()
+    {
+        Items.Add(new AgentItemVm { Status = AgentStatus.Online, Name = "Alpha", Host = "alpha.local", Tags = "prod", Version = "1.0", Uptime = "1d", Platform = "Windows", CpuRam = "10%/2GB", Ping = "10ms", LastSeen = "now", Fingerprint = "AA:BB" });
+        Items.Add(new AgentItemVm { Status = AgentStatus.Online, Name = "Beta", Host = "beta.local", Tags = "staging", Version = "1.0", Uptime = "2d", Platform = "Linux", CpuRam = "20%/1GB", Ping = "20ms", LastSeen = "1m", Fingerprint = "CC:DD" });
+        Items.Add(new AgentItemVm { Status = AgentStatus.Offline, Name = "Gamma", Host = "gamma.local", Tags = "prod", Version = "1.0", Uptime = "5h", Platform = "Windows", CpuRam = "15%/3GB", Ping = "-", LastSeen = "1h", Fingerprint = "EE:FF" });
+        Items.Add(new AgentItemVm { Status = AgentStatus.Pending, Name = "Delta", Host = "delta.local", Tags = "test", Version = "1.0", Uptime = "3h", Platform = "Linux", CpuRam = "5%/512MB", Ping = "15ms", LastSeen = "now", Fingerprint = "GG:HH" });
+        Items.Add(new AgentItemVm { Status = AgentStatus.Quarantine, Name = "Epsilon", Host = "eps.local", Tags = "quarantine", Version = "1.0", Uptime = "1h", Platform = "Windows", CpuRam = "50%/4GB", Ping = "-", LastSeen = "5m", Fingerprint = "II:JJ" });
+    }
+
+    private void DebounceFilter()
+    {
+        searchDebounceCts?.Cancel();
+        var cts = searchDebounceCts = new CancellationTokenSource();
+        Task.Delay(300, cts.Token).ContinueWith(t =>
+        {
+            if (!t.IsCanceled)
+            {
+                Application.Current.Dispatcher.Invoke(() => View.Refresh());
+            }
+        });
+    }
+
+    private bool Filter(object obj)
+    {
+        if (obj is not AgentItemVm agent) return false;
+        if (activeStatusFilter != AgentStatus.All && agent.Status != activeStatusFilter)
+            return false;
+        if (!string.IsNullOrWhiteSpace(searchQuery))
+        {
+            var q = searchQuery.ToLowerInvariant();
+            if (!(agent.Name.ToLowerInvariant().Contains(q) ||
+                  agent.Host.ToLowerInvariant().Contains(q) ||
+                  agent.Tags.ToLowerInvariant().Contains(q) ||
+                  agent.Fingerprint.ToLowerInvariant().Contains(q)))
+                return false;
+        }
+        return true;
+    }
+
+    partial void OnActiveStatusFilterChanged(AgentStatus value)
+    {
+        View.Refresh();
+    }
+
+    public IAsyncRelayCommand<AgentItemVm> OpenDetailsCmd => new AsyncRelayCommand<AgentItemVm>(async agent =>
+    {
+        SelectedItem = agent;
+        IsDetailsOpen = true;
+        await Task.CompletedTask;
+    });
+
+    public IAsyncRelayCommand<AgentItemVm> TrustCmd => new AsyncRelayCommand<AgentItemVm>(_ => Task.CompletedTask);
+    public IAsyncRelayCommand<AgentItemVm> RejectCmd => new AsyncRelayCommand<AgentItemVm>(_ => Task.CompletedTask);
+    public IAsyncRelayCommand<AgentItemVm> OpenFilesCmd => new AsyncRelayCommand<AgentItemVm>(_ => Task.CompletedTask);
+    public IAsyncRelayCommand<AgentItemVm> OpenTerminalCmd => new AsyncRelayCommand<AgentItemVm>(_ => Task.CompletedTask);
+    public IAsyncRelayCommand<AgentItemVm> RestartCmd => new AsyncRelayCommand<AgentItemVm>(_ => Task.CompletedTask);
+
+    public IRelayCommand CloseDetailsCmd => new RelayCommand(() => IsDetailsOpen = false);
+}

--- a/src/RemoteManager/Views/Agents/AgentDetailsDrawer.xaml
+++ b/src/RemoteManager/Views/Agents/AgentDetailsDrawer.xaml
@@ -1,0 +1,24 @@
+<UserControl x:Class="RemoteManager.Views.Agents.AgentDetailsDrawer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:views="clr-namespace:RemoteManager.Views.Agents">
+    <Border Background="{DynamicResource Brush.Background}" BorderBrush="{DynamicResource Brush.Foreground}" BorderThickness="1">
+        <ScrollViewer>
+            <StackPanel Margin="16">
+                <TextBlock Text="{DynamicResource Agents.Details.DeviceId}" FontWeight="Bold" />
+                <TextBlock Text="{Binding DeviceId}" Margin="0,0,0,8" />
+                <TextBlock Text="{DynamicResource Agents.Details.Hostname}" FontWeight="Bold" />
+                <TextBlock Text="{Binding Host}" Margin="0,0,0,8" />
+                <TextBlock Text="{DynamicResource Agents.Details.Tags}" FontWeight="Bold" />
+                <TextBox Text="{Binding Tags}" Margin="0,0,0,8" />
+                <TextBlock Text="{DynamicResource Agents.Details.Fingerprint}" FontWeight="Bold" />
+                <TextBlock Text="{Binding Fingerprint}" Margin="0,0,0,8" />
+                <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
+                    <Button Content="{DynamicResource Agents.Details.TrustBtn}" Style="{DynamicResource PrimaryButton}" Command="{Binding DataContext.TrustCmd, RelativeSource={RelativeSource AncestorType=views:AgentsView}}" CommandParameter="{Binding}" Margin="0,0,8,0" />
+                    <Button Content="{DynamicResource Agents.Details.RejectBtn}" Style="{DynamicResource DangerButton}" Command="{Binding DataContext.RejectCmd, RelativeSource={RelativeSource AncestorType=views:AgentsView}}" CommandParameter="{Binding}" />
+                </StackPanel>
+                <Button Content="{DynamicResource Agents.Details.CloseBtn}" Style="{DynamicResource GhostButton}" Command="{Binding DataContext.CloseDetailsCmd, RelativeSource={RelativeSource AncestorType=views:AgentsView}}" Margin="0,16,0,0" />
+            </StackPanel>
+        </ScrollViewer>
+    </Border>
+</UserControl>

--- a/src/RemoteManager/Views/Agents/AgentDetailsDrawer.xaml.cs
+++ b/src/RemoteManager/Views/Agents/AgentDetailsDrawer.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace RemoteManager.Views.Agents;
+
+public partial class AgentDetailsDrawer : UserControl
+{
+    public AgentDetailsDrawer()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/RemoteManager/Views/Agents/AgentsView.xaml
+++ b/src/RemoteManager/Views/Agents/AgentsView.xaml
@@ -1,0 +1,123 @@
+<UserControl x:Class="RemoteManager.Views.Agents.AgentsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:RemoteManager.ViewModels.Agents"
+             xmlns:conv="clr-namespace:RemoteManager.Converters"
+             xmlns:views="clr-namespace:RemoteManager.Views.Agents"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:AgentsViewModel}">
+    <UserControl.Resources>
+        <conv:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+    </UserControl.Resources>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <DockPanel Grid.Column="0">
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,8">
+                <Grid Width="200" Margin="0,0,8,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="{DynamicResource Icon.Search}" FontFamily="Segoe MDL2 Assets" VerticalAlignment="Center" Margin="0,0,4,0" />
+                    <TextBox Grid.Column="1" Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}" />
+                </Grid>
+                <StackPanel Orientation="Horizontal">
+                    <ToggleButton Content="{DynamicResource Agents.Filter.All}"
+                                  IsChecked="{Binding ActiveStatusFilter, Mode=TwoWay, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=All}"
+                                  Style="{DynamicResource GhostButton}" Margin="0,0,4,0" />
+                    <ToggleButton Content="{DynamicResource Agents.Filter.Online}"
+                                  IsChecked="{Binding ActiveStatusFilter, Mode=TwoWay, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Online}"
+                                  Style="{DynamicResource GhostButton}" Margin="0,0,4,0" />
+                    <ToggleButton Content="{DynamicResource Agents.Filter.Offline}"
+                                  IsChecked="{Binding ActiveStatusFilter, Mode=TwoWay, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Offline}"
+                                  Style="{DynamicResource GhostButton}" Margin="0,0,4,0" />
+                    <ToggleButton Content="{DynamicResource Agents.Filter.Pending}"
+                                  IsChecked="{Binding ActiveStatusFilter, Mode=TwoWay, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Pending}"
+                                  Style="{DynamicResource GhostButton}" Margin="0,0,4,0" />
+                    <ToggleButton Content="{DynamicResource Agents.Filter.Quarantine}"
+                                  IsChecked="{Binding ActiveStatusFilter, Mode=TwoWay, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Quarantine}"
+                                  Style="{DynamicResource GhostButton}" />
+                </StackPanel>
+            </StackPanel>
+            <Grid>
+                <DataGrid ItemsSource="{Binding View}" SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                          AutoGenerateColumns="False" SelectionMode="Single"
+                          EnableRowVirtualization="True" EnableColumnVirtualization="True"
+                          VirtualizingPanel.IsVirtualizing="True" ScrollViewer.CanContentScroll="True">
+                    <DataGrid.Columns>
+                        <DataGridTemplateColumn Header="{DynamicResource Agents.Header.Status}">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Border x:Name="badge" Style="{DynamicResource Badge.Online}">
+                                        <TextBlock Text="{Binding Status}" Foreground="{DynamicResource Brush.Background}" />
+                                    </Border>
+                                    <DataTemplate.Triggers>
+                                        <DataTrigger Binding="{Binding Status}" Value="Pending">
+                                            <Setter TargetName="badge" Property="Style" Value="{DynamicResource Badge.Pending}" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Status}" Value="Offline">
+                                            <Setter TargetName="badge" Property="Style" Value="{DynamicResource Badge.Offline}" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Status}" Value="Quarantine">
+                                            <Setter TargetName="badge" Property="Style" Value="{DynamicResource Badge.Quarantine}" />
+                                        </DataTrigger>
+                                    </DataTemplate.Triggers>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.Name}" Binding="{Binding Name}" />
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.Host}" Binding="{Binding Host}" />
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.Group}" Binding="{Binding Tags}" />
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.Version}" Binding="{Binding Version}" />
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.Uptime}" Binding="{Binding Uptime}" />
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.Platform}" Binding="{Binding Platform}" />
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.CpuRam}" Binding="{Binding CpuRam}" />
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.Ping}" Binding="{Binding Ping}" />
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.LastSeen}" Binding="{Binding LastSeen}" />
+                        <DataGridTextColumn Header="{DynamicResource Agents.Header.Fingerprint}" Binding="{Binding Fingerprint}" />
+                        <DataGridTemplateColumn Header="{DynamicResource Agents.Header.Actions}">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                        <Button Content="{DynamicResource Agents.Action.OpenDetails}" Command="{Binding DataContext.OpenDetailsCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" Style="{DynamicResource GhostButton}" Margin="0,0,4,0" />
+                                        <Button Content="{DynamicResource Agents.Action.Trust}" Command="{Binding DataContext.TrustCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" Style="{DynamicResource GhostButton}" Margin="0,0,4,0" />
+                                        <Button Content="{DynamicResource Agents.Action.Reject}" Command="{Binding DataContext.RejectCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" Style="{DynamicResource GhostButton}" Margin="0,0,4,0" />
+                                        <Button Content="{DynamicResource Agents.Action.Files}" Command="{Binding DataContext.OpenFilesCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" Style="{DynamicResource GhostButton}" Margin="0,0,4,0" />
+                                        <Button Content="{DynamicResource Agents.Action.Terminal}" Command="{Binding DataContext.OpenTerminalCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" Style="{DynamicResource GhostButton}" Margin="0,0,4,0" />
+                                        <Button Content="{DynamicResource Agents.Action.Restart}" Command="{Binding DataContext.RestartCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" Style="{DynamicResource GhostButton}" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                    </DataGrid.Columns>
+                    <DataGrid.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="{DynamicResource Agents.Action.OpenDetails}" Command="{Binding DataContext.OpenDetailsCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" />
+                            <MenuItem Header="{DynamicResource Agents.Action.Trust}" Command="{Binding DataContext.TrustCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" />
+                            <MenuItem Header="{DynamicResource Agents.Action.Reject}" Command="{Binding DataContext.RejectCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" />
+                            <MenuItem Header="{DynamicResource Agents.Action.Files}" Command="{Binding DataContext.OpenFilesCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" />
+                            <MenuItem Header="{DynamicResource Agents.Action.Terminal}" Command="{Binding DataContext.OpenTerminalCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" />
+                            <MenuItem Header="{DynamicResource Agents.Action.Restart}" Command="{Binding DataContext.RestartCmd, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" />
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                </DataGrid>
+                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
+                            Visibility="{Binding View.IsEmpty, Converter={StaticResource BoolToVis}}">
+                    <TextBlock Text="{DynamicResource Agents.Empty.Message}" Margin="0,0,0,8" />
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Button Content="{DynamicResource Agents.Empty.ScanNetwork}" Style="{DynamicResource PrimaryButton}" Margin="0,0,8,0" />
+                        <Button Content="{DynamicResource Agents.Empty.AddManual}" Style="{DynamicResource GhostButton}" />
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </DockPanel>
+        <views:AgentDetailsDrawer Grid.Column="1" Width="420" DataContext="{Binding SelectedItem}"
+                                  Visibility="{Binding IsDetailsOpen, Converter={StaticResource BoolToVis}}" />
+    </Grid>
+</UserControl>

--- a/src/RemoteManager/Views/Agents/AgentsView.xaml.cs
+++ b/src/RemoteManager/Views/Agents/AgentsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace RemoteManager.Views.Agents;
+
+public partial class AgentsView : UserControl
+{
+    public AgentsView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- add theme resource dictionaries and button/badge styles
- implement Agents screen with search, filters and virtualization
- show agent detail drawer with basic actions

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab69526fa88332a6aa08505cc9671e