### PR TITLE
feat(shell): add MainWindow shell with navigation and status bar

### DIFF
--- a/src/RemoteManager/App.xaml
+++ b/src/RemoteManager/App.xaml
@@ -1,11 +1,13 @@
 <Application x:Class="RemoteManager.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="Views/MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources/Theme/Theme.xaml" />
+                <ResourceDictionary Source="Resources/ViewLocator.xaml" />
                 <ResourceDictionary Source="Resources/Strings.xaml" />
+                <ResourceDictionary Source="Resources/Theme/Theme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/RemoteManager/App.xaml.cs
+++ b/src/RemoteManager/App.xaml.cs
@@ -4,8 +4,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using RemoteManager.Services;
+using RemoteManager.Services.Navigation;
 using RemoteManager.ViewModels;
-using RemoteManager.Views;
+using RemoteManager.ViewModels.Agents;
 using Serilog;
 
 namespace RemoteManager
@@ -40,10 +41,13 @@ namespace RemoteManager
                     services.AddSingleton<ISystemClient>(sp => new SystemClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));
                     services.AddSingleton<IFileClient>(sp => new FileClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));
                     services.AddSingleton<IProcessClient>(sp => new ProcessClient(sp.GetRequiredService<IGrpcConnectionFactory>().Create(endpoint)));
-                    services.AddSingleton<ShellViewModel>();
-                    services.AddSingleton<AgentListViewModel>();
+
+                    services.AddSingleton<INavigationService, NavigationService>();
+                    services.AddSingleton<AgentsViewModel>();
+                    services.AddSingleton<InboxViewModel>();
                     services.AddSingleton<CommanderViewModel>();
-                    services.AddSingleton<MainWindow>();
+                    services.AddSingleton<SettingsViewModel>();
+                    services.AddSingleton<MainWindowViewModel>();
                 })
                 .Build();
             Host.Start();
@@ -58,12 +62,6 @@ namespace RemoteManager
             {
                 logger.LogInformation("Discovery receive disabled (dev)");
             }
-        }
-
-        protected override void OnStartup(StartupEventArgs e)
-        {
-            base.OnStartup(e);
-            Host.Services.GetRequiredService<MainWindow>().Show();
         }
 
         protected override void OnExit(ExitEventArgs e)

--- a/src/RemoteManager/Resources/Strings.xaml
+++ b/src/RemoteManager/Resources/Strings.xaml
@@ -33,6 +33,28 @@
     <x:String x:Key="Agents.Search.Placeholder">Search agents...</x:String>
     <x:String x:Key="Icon.Search">&#xE721;</x:String>
 
+    <!-- Navigation -->
+    <x:String x:Key="Nav.Agents">Agents</x:String>
+    <x:String x:Key="Nav.Inbox">Inbox</x:String>
+    <x:String x:Key="Nav.Commander">Commander</x:String>
+    <x:String x:Key="Nav.Settings">Settings</x:String>
+    <x:String x:Key="Nav.ScanNetwork">Scan network</x:String>
+
+    <!-- Icons -->
+    <x:String x:Key="Icon.Agents">&#xE716;</x:String>
+    <x:String x:Key="Icon.Inbox">&#xE8BD;</x:String>
+    <x:String x:Key="Icon.Commander">&#xE756;</x:String>
+    <x:String x:Key="Icon.Settings">&#xE713;</x:String>
+
+    <!-- Banner -->
+    <x:String x:Key="Banner.InboxFound">Found new devices: {0} — View</x:String>
+
+    <!-- Status bar -->
+    <x:String x:Key="StatusBar.Online">Online</x:String>
+    <x:String x:Key="StatusBar.Offline">Offline</x:String>
+    <x:String x:Key="StatusBar.Pending">Pending</x:String>
+    <x:String x:Key="StatusBar.LastContact">Last contact</x:String>
+
     <!-- Empty state -->
     <x:String x:Key="Agents.Empty.Message">No agents found</x:String>
     <x:String x:Key="Agents.Empty.ScanNetwork">Scan network</x:String>

--- a/src/RemoteManager/Resources/ViewLocator.xaml
+++ b/src/RemoteManager/Resources/ViewLocator.xaml
@@ -1,0 +1,19 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:views="clr-namespace:RemoteManager.Views"
+                    xmlns:viewsAgents="clr-namespace:RemoteManager.Views.Agents"
+                    xmlns:vm="clr-namespace:RemoteManager.ViewModels"
+                    xmlns:vmAgents="clr-namespace:RemoteManager.ViewModels.Agents">
+    <DataTemplate DataType="{x:Type vmAgents:AgentsViewModel}">
+        <viewsAgents:AgentsView />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vm:InboxViewModel}">
+        <views:InboxView />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vm:CommanderViewModel}">
+        <views:CommanderView />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vm:SettingsViewModel}">
+        <views:SettingsView />
+    </DataTemplate>
+</ResourceDictionary>

--- a/src/RemoteManager/Services/Navigation/INavigationService.cs
+++ b/src/RemoteManager/Services/Navigation/INavigationService.cs
@@ -1,0 +1,8 @@
+namespace RemoteManager.Services.Navigation;
+
+using RemoteManager.ViewModels;
+
+public interface INavigationService
+{
+    object Resolve(NavKey key);
+}

--- a/src/RemoteManager/Services/Navigation/NavigationService.cs
+++ b/src/RemoteManager/Services/Navigation/NavigationService.cs
@@ -1,0 +1,25 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using RemoteManager.ViewModels;
+using RemoteManager.ViewModels.Agents;
+
+namespace RemoteManager.Services.Navigation;
+
+public class NavigationService : INavigationService
+{
+    private readonly IServiceProvider _services;
+
+    public NavigationService(IServiceProvider services)
+    {
+        _services = services;
+    }
+
+    public object Resolve(NavKey key) => key switch
+    {
+        NavKey.Agents => _services.GetRequiredService<AgentsViewModel>(),
+        NavKey.Inbox => _services.GetRequiredService<InboxViewModel>(),
+        NavKey.Commander => _services.GetRequiredService<CommanderViewModel>(),
+        NavKey.Settings => _services.GetRequiredService<SettingsViewModel>(),
+        _ => throw new ArgumentOutOfRangeException(nameof(key), key, null)
+    };
+}

--- a/src/RemoteManager/ViewModels/InboxViewModel.cs
+++ b/src/RemoteManager/ViewModels/InboxViewModel.cs
@@ -1,0 +1,7 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace RemoteManager.ViewModels;
+
+public class InboxViewModel : ObservableObject
+{
+}

--- a/src/RemoteManager/ViewModels/MainWindowViewModel.cs
+++ b/src/RemoteManager/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,117 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using RemoteManager.Services;
+using RemoteManager.Services.Navigation;
+using RemoteManager.ViewModels.Agents;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+
+namespace RemoteManager.ViewModels;
+
+public partial class MainWindowViewModel : ObservableObject
+{
+    private readonly INavigationService _navigation;
+    private readonly IDiscoveryService _discovery;
+
+    public ObservableCollection<NavItemVm> NavItems { get; } = new();
+
+    [ObservableProperty]
+    private NavItemVm? selectedNavItem;
+
+    [ObservableProperty]
+    private object? currentViewModel;
+
+    [ObservableProperty]
+    private int inboxCount;
+
+    [ObservableProperty]
+    private int onlineCount;
+
+    [ObservableProperty]
+    private int offlineCount;
+
+    [ObservableProperty]
+    private int pendingCount;
+
+    [ObservableProperty]
+    private string searchQuery = string.Empty;
+
+    [ObservableProperty]
+    private string statusText = string.Empty;
+
+    [ObservableProperty]
+    private string currentTitle = string.Empty;
+
+    [ObservableProperty]
+    private string inboxBannerText = string.Empty;
+
+    public IRelayCommand<NavItemVm> NavigateCommand { get; }
+    public IAsyncRelayCommand ScanNetworkCommand { get; }
+
+    public MainWindowViewModel(INavigationService navigation, IDiscoveryService discovery)
+    {
+        _navigation = navigation;
+        _discovery = discovery;
+
+        NavItems.Add(new NavItemVm { TitleKey = "Nav.Agents", IconKey = "Icon.Agents", Key = NavKey.Agents });
+        NavItems.Add(new NavItemVm { TitleKey = "Nav.Inbox", IconKey = "Icon.Inbox", Key = NavKey.Inbox });
+        NavItems.Add(new NavItemVm { TitleKey = "Nav.Commander", IconKey = "Icon.Commander", Key = NavKey.Commander });
+        NavItems.Add(new NavItemVm { TitleKey = "Nav.Settings", IconKey = "Icon.Settings", Key = NavKey.Settings });
+
+        NavigateCommand = new RelayCommand<NavItemVm>(Navigate);
+        ScanNetworkCommand = new AsyncRelayCommand(_discovery.DiscoverAsync);
+
+        SelectedNavItem = NavItems.First();
+        Navigate(SelectedNavItem);
+        OnInboxCountChanged(InboxCount);
+    }
+
+    private void Navigate(NavItemVm? item)
+    {
+        if (item == null) return;
+        SelectedNavItem = item;
+        CurrentViewModel = _navigation.Resolve(item.Key);
+        CurrentTitle = item.Title;
+        if (CurrentViewModel is AgentsViewModel avm)
+        {
+            avm.SearchQuery = SearchQuery;
+            UpdateCountsFromAgents(avm);
+        }
+    }
+
+    partial void OnInboxCountChanged(int value)
+    {
+        var inboxItem = NavItems.FirstOrDefault(n => n.Key == NavKey.Inbox);
+        if (inboxItem != null)
+            inboxItem.BadgeCount = value > 0 ? value : null;
+        var template = Application.Current.TryFindResource("Banner.InboxFound") as string ?? "Found new devices: {0} — View";
+        InboxBannerText = string.Format(template, value);
+    }
+
+    partial void OnSearchQueryChanged(string value)
+    {
+        if (CurrentViewModel is AgentsViewModel avm)
+            avm.SearchQuery = value;
+    }
+
+    partial void OnOnlineCountChanged(int value) => UpdateStatus();
+    partial void OnOfflineCountChanged(int value) => UpdateStatus();
+    partial void OnPendingCountChanged(int value) => UpdateStatus();
+
+    private void UpdateStatus()
+    {
+        string online = Application.Current.TryFindResource("StatusBar.Online") as string ?? "Online";
+        string offline = Application.Current.TryFindResource("StatusBar.Offline") as string ?? "Offline";
+        string pending = Application.Current.TryFindResource("StatusBar.Pending") as string ?? "Pending";
+        string last = Application.Current.TryFindResource("StatusBar.LastContact") as string ?? "Last contact";
+        StatusText = $"{online}: {OnlineCount} | {offline}: {OfflineCount} | {pending}: {PendingCount} | {last}: -";
+    }
+
+    private void UpdateCountsFromAgents(AgentsViewModel vm)
+    {
+        OnlineCount = vm.Items.Count(i => i.Status == AgentStatus.Online);
+        OfflineCount = vm.Items.Count(i => i.Status == AgentStatus.Offline);
+        PendingCount = vm.Items.Count(i => i.Status == AgentStatus.Pending);
+    }
+}

--- a/src/RemoteManager/ViewModels/NavItemVm.cs
+++ b/src/RemoteManager/ViewModels/NavItemVm.cs
@@ -1,0 +1,17 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Windows;
+
+namespace RemoteManager.ViewModels;
+
+public partial class NavItemVm : ObservableObject
+{
+    public string TitleKey { get; init; } = string.Empty;
+    public string IconKey { get; init; } = string.Empty;
+    public NavKey Key { get; init; }
+
+    [ObservableProperty]
+    private int? badgeCount;
+
+    public string Title => Application.Current.TryFindResource(TitleKey) as string ?? TitleKey;
+    public string Icon => Application.Current.TryFindResource(IconKey) as string ?? string.Empty;
+}

--- a/src/RemoteManager/ViewModels/NavKey.cs
+++ b/src/RemoteManager/ViewModels/NavKey.cs
@@ -1,0 +1,9 @@
+namespace RemoteManager.ViewModels;
+
+public enum NavKey
+{
+    Agents,
+    Inbox,
+    Commander,
+    Settings
+}

--- a/src/RemoteManager/ViewModels/SettingsViewModel.cs
+++ b/src/RemoteManager/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,7 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace RemoteManager.ViewModels;
+
+public class SettingsViewModel : ObservableObject
+{
+}

--- a/src/RemoteManager/Views/InboxView.xaml
+++ b/src/RemoteManager/Views/InboxView.xaml
@@ -1,0 +1,7 @@
+<UserControl x:Class="RemoteManager.Views.InboxView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <TextBlock Text="{DynamicResource Nav.Inbox}" />
+    </Grid>
+</UserControl>

--- a/src/RemoteManager/Views/InboxView.xaml.cs
+++ b/src/RemoteManager/Views/InboxView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace RemoteManager.Views;
+
+public partial class InboxView : UserControl
+{
+    public InboxView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/RemoteManager/Views/MainWindow.xaml
+++ b/src/RemoteManager/Views/MainWindow.xaml
@@ -3,9 +3,93 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:RemoteManager.ViewModels"
         mc:Ignorable="d"
         Title="RemoteManager" Height="450" Width="800">
     <Grid>
-        <ContentPresenter Content="{Binding}" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Navigation -->
+        <Border Grid.RowSpan="4" Background="{DynamicResource Brush.Background}" Padding="8">
+            <ItemsControl ItemsSource="{Binding NavItems}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type vm:NavItemVm}">
+                        <Button Command="{Binding DataContext.NavigateCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                CommandParameter="{Binding}"
+                                Style="{DynamicResource GhostButton}"
+                                HorizontalContentAlignment="Stretch" Margin="0,4">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Icon}" FontFamily="Segoe MDL2 Assets" Margin="0,0,8,0"/>
+                                <TextBlock Text="{Binding Title}"/>
+                                <Border Style="{DynamicResource Badge.Pending}" Margin="8,0,0,0">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding BadgeCount}" Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding BadgeCount}" Value="0">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding BadgeCount}">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <TextBlock Text="{Binding BadgeCount}" Foreground="{DynamicResource Brush.Background}"/>
+                                </Border>
+                            </StackPanel>
+                        </Button>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Border>
+
+        <!-- Top bar -->
+        <Grid Grid.Column="1" Grid.Row="0" Padding="8" Background="{DynamicResource Brush.Background}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="200"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="{Binding CurrentTitle}" FontSize="20" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="1" Margin="8,0" Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"/>
+            <Button Grid.Column="2" Content="{DynamicResource Nav.ScanNetwork}" Command="{Binding ScanNetworkCommand}" Style="{DynamicResource PrimaryButton}" Margin="8,0"/>
+        </Grid>
+
+        <!-- Banner -->
+        <Button Grid.Column="1" Grid.Row="1" Background="{DynamicResource Brush.Warning}" Foreground="{DynamicResource Brush.Foreground}"
+                BorderThickness="0" Padding="8" Content="{Binding InboxBannerText}"
+                Command="{Binding NavigateCommand}" CommandParameter="{Binding NavItems[1]}">
+            <Button.Style>
+                <Style TargetType="Button">
+                    <Setter Property="Visibility" Value="Visible"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding InboxCount}" Value="0">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Button.Style>
+        </Button>
+
+        <!-- Content -->
+        <ContentControl Grid.Column="1" Grid.Row="2" Content="{Binding CurrentViewModel}"/>
+
+        <!-- Status bar -->
+        <Border Grid.Column="1" Grid.Row="3" Background="{DynamicResource Brush.Background}" Padding="4">
+            <TextBlock Text="{Binding StatusText}"/>
+        </Border>
     </Grid>
 </Window>

--- a/src/RemoteManager/Views/MainWindow.xaml.cs
+++ b/src/RemoteManager/Views/MainWindow.xaml.cs
@@ -1,13 +1,14 @@
 using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
 using RemoteManager.ViewModels;
 
 namespace RemoteManager.Views;
 
 public partial class MainWindow : Window
 {
-    public MainWindow(ShellViewModel vm)
+    public MainWindow()
     {
         InitializeComponent();
-        DataContext = vm;
+        DataContext = ((App)Application.Current).Host.Services.GetRequiredService<MainWindowViewModel>();
     }
 }

--- a/src/RemoteManager/Views/SettingsView.xaml
+++ b/src/RemoteManager/Views/SettingsView.xaml
@@ -1,0 +1,7 @@
+<UserControl x:Class="RemoteManager.Views.SettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <TextBlock Text="{DynamicResource Nav.Settings}" />
+    </Grid>
+</UserControl>

--- a/src/RemoteManager/Views/SettingsView.xaml.cs
+++ b/src/RemoteManager/Views/SettingsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace RemoteManager.Views;
+
+public partial class SettingsView : UserControl
+{
+    public SettingsView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- implement navigation service and view locator using DataTemplates
- create MainWindow shell with left nav, banner, search, and status bar
- add localized strings and merge resources for navigation and banner

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab75627eb48332a6eabc9de3152962