### PR TITLE
Fix WPF style misconfiguration causing build errors

### DIFF
--- a/src/RemoteManager/Resources/Theme/Theme.xaml
+++ b/src/RemoteManager/Resources/Theme/Theme.xaml
@@ -13,7 +13,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource Brush.Success}" />
     </Style>
 
-    <Style x:Key="GhostButton" TargetType="Button">
+    <Style x:Key="GhostButton" TargetType="{x:Type ButtonBase}">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{DynamicResource Brush.Foreground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Brush.Foreground}" />

--- a/src/RemoteManager/Views/MainWindow.xaml
+++ b/src/RemoteManager/Views/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:vm="clr-namespace:RemoteManager.ViewModels"
+        xmlns:vm="clr-namespace:RemoteManager.ViewModels;assembly=RemoteManager"
         mc:Ignorable="d"
         Title="RemoteManager" Height="450" Width="800">
     <Grid>
@@ -30,9 +30,9 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="{Binding Icon}" FontFamily="Segoe MDL2 Assets" Margin="0,0,8,0"/>
                                 <TextBlock Text="{Binding Title}"/>
-                                <Border Style="{DynamicResource Badge.Pending}" Margin="8,0,0,0">
+                                <Border Margin="8,0,0,0">
                                     <Border.Style>
-                                        <Style TargetType="Border">
+                                        <Style TargetType="Border" BasedOn="{StaticResource Badge.Pending}">
                                             <Setter Property="Visibility" Value="Collapsed" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding BadgeCount}" Value="{x:Null}">


### PR DESCRIPTION
## Summary
- Make `GhostButton` style apply to all `ButtonBase` controls so it can style `ToggleButton`
- Use a `Badge.Pending`-based border style with triggers to avoid setting the `Style` property twice
- Explicitly reference `RemoteManager` assembly for `NavItemVm`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab99ee91148332bd74e00b73d932f6