### PR TITLE
Fix NavItemVm XAML reference and remove invalid Grid padding

### DIFF
--- a/src/RemoteManager/Views/MainWindow.xaml
+++ b/src/RemoteManager/Views/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:vm="clr-namespace:RemoteManager.ViewModels;assembly=RemoteManager"
+        xmlns:vm="clr-namespace:RemoteManager.ViewModels"
         mc:Ignorable="d"
         Title="RemoteManager" Height="450" Width="800">
     <Grid>
@@ -57,16 +57,18 @@
         </Border>
 
         <!-- Top bar -->
-        <Grid Grid.Column="1" Grid.Row="0" Padding="8" Background="{DynamicResource Brush.Background}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="200"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <TextBlock Text="{Binding CurrentTitle}" FontSize="20" VerticalAlignment="Center"/>
-            <TextBox Grid.Column="1" Margin="8,0" Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"/>
-            <Button Grid.Column="2" Content="{DynamicResource Nav.ScanNetwork}" Command="{Binding ScanNetworkCommand}" Style="{DynamicResource PrimaryButton}" Margin="8,0"/>
-        </Grid>
+        <Border Grid.Column="1" Grid.Row="0" Padding="8" Background="{DynamicResource Brush.Background}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="200"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{Binding CurrentTitle}" FontSize="20" VerticalAlignment="Center"/>
+                <TextBox Grid.Column="1" Margin="8,0" Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"/>
+                <Button Grid.Column="2" Content="{DynamicResource Nav.ScanNetwork}" Command="{Binding ScanNetworkCommand}" Style="{DynamicResource PrimaryButton}" Margin="8,0"/>
+            </Grid>
+        </Border>
 
         <!-- Banner -->
         <Button Grid.Column="1" Grid.Row="1" Background="{DynamicResource Brush.Warning}" Foreground="{DynamicResource Brush.Foreground}"


### PR DESCRIPTION
## Summary
- Reference ViewModels namespace without specifying assembly to resolve NavItemVm.
- Replace top bar Grid padding with Border to avoid invalid Padding property.

## Testing
- ⚠️ `dotnet test` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9b203db48332b5cee9833667e542